### PR TITLE
Allow blank lines on requirements.txt

### DIFF
--- a/src/poetrify/files.py
+++ b/src/poetrify/files.py
@@ -64,6 +64,9 @@ def find_packages(requirements_txt_lines):
         if line.startswith("#"):
             continue
 
+        if "#" in line:
+            line = line.split("#")[0]
+
         if "egg=" in line:
             continue
 

--- a/src/poetrify/files.py
+++ b/src/poetrify/files.py
@@ -39,7 +39,7 @@ class RequirementsTxt:
 
     def __post_init__(self):
         with open(self.path) as f:
-            self.body = [l.strip() for l in f.readlines()]
+            self.body = [l.strip() for l in f.read().splitlines() if l.strip()]
 
     @property
     def all_packages(self):

--- a/tests/fixtures/requirements.txt
+++ b/tests/fixtures/requirements.txt
@@ -5,6 +5,9 @@ Django==2.1.5
 more-itertools==5.0.0
 pluggy==0.8.1
 py==1.7.0
-pytest==4.1.1
+
+    
+# The lines above are intentionally empty or only spaces for testing purpose
+pytest==4.1.1 
 pytz==2018.9
 six==1.12.0

--- a/tests/fixtures/requirements.txt
+++ b/tests/fixtures/requirements.txt
@@ -4,10 +4,10 @@ attrs==18.2.0
 Django==2.1.5
 more-itertools==5.0.0
 pluggy==0.8.1
-py==1.7.0
+py==1.7.0 
 
     
 # The lines above are intentionally empty or only spaces for testing purpose
-pytest==4.1.1 
+pytest==4.1.1 # https://github.com/pytest-dev/pytest (inline comment test)
 pytz==2018.9
 six==1.12.0


### PR DESCRIPTION
Hi there,

I tried this great tool for my requirements.txt based project and I found it does not work if the file has blank lines. This is a fix. 
(It's hard to see but the fixture file has two blank lines, the first of which is just "\n" but the second line has some spaces.)

Also, the project was originally created by cookiecutter-django and its requirements.txt's equivalents has inline comments like this so I added a change to adapt to those.
`pytest==5.3.5  # https://github.com/pytest-dev/pytest`

Thanks!